### PR TITLE
Update troubleshooting for Debian/Ubuntu package systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Run ```vagrant up``` to start the envirement. Run ```vagrant ssh``` to connect t
 * Logging is not supported (yet).
 
 ## Troubleshooting
-Some versions of Node.js (especially those packaged for Ubuntu) name their main binary ```nodejs``` instead of ```node```. The symptom of this problem is an error about the ```node``` binary not being found in the path even though Node.js is installed. This can be fixed with ```sudo ln -s $(which nodejs) /usr/local/bin/node```.
+Some versions of Node.js (especially those packaged for Ubuntu) name their main binary ```nodejs``` instead of ```node```. The symptom of this problem is an error about the ```node``` binary not being found in the path even though Node.js is installed. This can be fixed with ```sudo ln -s $(which nodejs) /usr/local/bin/node```. There's also a package called `nodejs-legacy` that can be installed in some debian and ubuntu distros that creates a symlink `node` in `/usr/bin/` 
 
 It may also be helpful to understand the nodejs environment that your Google Cloud Function runs in (e.g. how does regular `console.log` send logs to Stackdriver, whereas `fmt.Println` doesn't?). You can find more details in the [WORKERJS.md](WORKERJS.md) file.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Run ```vagrant up``` to start the envirement. Run ```vagrant ssh``` to connect t
 * Logging is not supported (yet).
 
 ## Troubleshooting
-Some versions of Node.js (especially those packaged for Ubuntu) name their main binary ```nodejs``` instead of ```node```. The symptom of this problem is an error about the ```node``` binary not being found in the path even though Node.js is installed. This can be fixed with ```sudo ln -s $(which nodejs) /usr/local/bin/node```. There's also a package called `nodejs-legacy` that can be installed in some debian and ubuntu distros that creates a symlink `node` in `/usr/bin/` 
+Some versions of Node.js (especially those packaged for Ubuntu) name their main binary ```nodejs``` instead of ```node```. The symptom of this problem is an error about the ```node``` binary not being found in the path even though Node.js is installed. This can be fixed with ```sudo ln -s $(which nodejs) /usr/local/bin/node```. There's also a package called `nodejs-legacy` that can be installed in some Debian and Ubuntu distros using `apt` that creates a symlink `node` in `/usr/bin/`
 
 It may also be helpful to understand the nodejs environment that your Google Cloud Function runs in (e.g. how does regular `console.log` send logs to Stackdriver, whereas `fmt.Println` doesn't?). You can find more details in the [WORKERJS.md](WORKERJS.md) file.
 


### PR DESCRIPTION
Instead of manually making a symlink there's a package in Debian an Ubuntu distros that creates those symlinks by itself  The package is `nodejs-legacy`. This is the package page in Debian Stretch https://packages.debian.org/stretch/nodejs-legacy

This updates README.md to reflect this.

* Debian wheezy-backports
* Debian jessie (oldstable)
* Debian jessie-backports
* Debian stretch (stable)
* Debian buster (testing)
* Ubuntu trusty (14.04LTS) 
* Ubuntu xenial (16.04LTS)
* Ubuntu xenial-updates 
* Ubuntu zesty 

Sources:
* https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=nodejs-legacy
* https://packages.debian.org/search?searchon=names&keywords=nodejs-legacy