### PR TITLE
Added support for logging via the supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,30 @@ Run ```make test``` to compile your code and start the test server. Open ```http
 
 When using a go-only or non-unix environment, run ```make godev``` instead.
 
+## Logging
+The logger may be used directly:
+```
+nodego.InfoLogger.Println("Hello World!")
+nodego.ErrorLogger.Println("Something went wrong!")
+```
+or via the log package after calling `nodego.OverrideLogger()`:
+```
+func init() {
+	nodego.OverrideLogger()
+}
+
+...
+
+log.Println("Hello World!")
+```
+Use the `nodego.WithLogger()` or `nodego.WithLoggerFunc()` middleware for your logs to reference the specific execution:
+```
+http.WithLoggerFunc(func(w http.ResponseWriter, r *http.Request) {
+	log.Println("Hello World!")
+})
+```
+A full example is included in [examples/logging.go](examples/logging.go).
+
 ## Deployment
 Run ```make``` to compile and package your code. Upload the generated ```function.zip``` file to Google Cloud Functions as an HTTP trigger function.
 
@@ -46,7 +70,6 @@ Run ```vagrant up``` to start the envirement. Run ```vagrant ssh``` to connect t
 
 ## Limitations
 * This has only been tested for HTTP trigger functions. Non-HTTP trigger functions will use a different endpoint (not ```/execute```).
-* Logging is not supported (yet).
 
 ## Troubleshooting
 Some versions of Node.js (especially those packaged for Ubuntu) name their main binary ```nodejs``` instead of ```node```. The symptom of this problem is an error about the ```node``` binary not being found in the path even though Node.js is installed. This can be fixed with ```sudo ln -s $(which nodejs) /usr/local/bin/node```. There's also a package called `nodejs-legacy` that can be installed in some Debian and Ubuntu distros using `apt` that creates a symlink `node` in `/usr/bin/`

--- a/examples/logging.go
+++ b/examples/logging.go
@@ -1,0 +1,37 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+
+	"../nodego"
+)
+
+func init() {
+	nodego.OverrideLogger()
+}
+
+func main() {
+	flag.Parse()
+
+	http.HandleFunc(nodego.HTTPTrigger, nodego.WithLoggerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Println("This is a log message from Go!")
+	}))
+
+	nodego.TakeOver()
+}

--- a/nodego/env.go
+++ b/nodego/env.go
@@ -1,3 +1,58 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package nodego
 
-const HTTPTrigger = "/execute"
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+// Variables copied from worker.js.
+var (
+	codeLocationDir        = os.Getenv("CODE_LOCATION")
+	packageJsonFile        = codeLocationDir + "/package.json"
+	entryPoint             = os.Getenv("ENTRY_POINT")
+	supervisorHostname     = os.Getenv("SUPERVISOR_HOSTNAME")
+	supervisorInternalPort = os.Getenv("SUPERVISOR_INTERNAL_PORT")
+	functionTriggerType    = os.Getenv("FUNCTION_TRIGGER_TYPE")
+	functionName           = os.Getenv("FUNCTION_NAME")
+	functionTimeoutSec, _  = strconv.ParseInt(os.Getenv("FUNCTION_TIMEOUT_SEC"), 10, 64)
+)
+
+// Constants copied from worker.js.
+const (
+	functionStatusHeaderField = "X-Google-Status"
+	fetcherOrigin             = "X-Google-Fetcher-Origin"
+	executePrefix             = "/execute"
+
+	maxLogLength          = 5000
+	maxLogBatchEntries    = 1500
+	maxLogBatchLength     = 150000
+	supervisorKillTimeout = 5 * time.Second
+)
+
+var (
+	supervisorLogTimeout = time.Duration(max(60, functionTimeoutSec)) * time.Second
+)
+
+func max(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+const HTTPTrigger = executePrefix

--- a/nodego/supervisor.go
+++ b/nodego/supervisor.go
@@ -1,0 +1,298 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodego
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type logEntry struct {
+	TextPayload string
+	Severity    string
+	Time        string
+	ExecutionID string
+}
+
+func (e *logEntry) consoleOutput() []byte {
+	var logBuf bytes.Buffer
+	fmt.Fprintf(&logBuf, "[%s]", e.Severity[:1])
+	fmt.Fprintf(&logBuf, "[%s]", time.Now().Format(isoTimeFormat))
+	if e.ExecutionID != "" {
+		fmt.Fprintf(&logBuf, "[%s]", e.ExecutionID)
+	}
+	logBuf.WriteByte(' ')
+	logBuf.WriteString(e.TextPayload)
+	if len(e.TextPayload) == 0 || e.TextPayload[len(e.TextPayload)-1] != '\n' {
+		logBuf.WriteByte('\n')
+	}
+	return logBuf.Bytes()
+}
+
+type logBatch struct {
+	Entries []*logEntry
+
+	payloadLength int
+	ready         chan struct{}
+}
+
+// addEntry adds a log entry to the batch.
+//
+// Note: addEntry is not thread safe.
+func (batch *logBatch) addEntry(entry *logEntry) {
+	if batch.Entries == nil {
+		close(batch.ready)
+	}
+
+	batch.Entries = append(batch.Entries, entry)
+	batch.payloadLength += len(entry.TextPayload)
+}
+
+func (batch *logBatch) report() error {
+	if len(batch.Entries) == 0 {
+		return nil
+	}
+
+	if err := postToSupervisor("/_ah/log", batch, supervisorLogTimeout); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type loggingContext struct {
+	initOnce sync.Once
+
+	queueMutex   sync.Mutex
+	queue        chan *logBatch
+	currentBatch *logBatch
+
+	execIDMutex sync.RWMutex
+	execID      string
+}
+
+// startNewBatch prepares a new batch.
+//
+// Note: startNewBatch is not thread safe.
+func (ctx *loggingContext) startNewBatch() *logBatch {
+	ctx.currentBatch = &logBatch{
+		ready: make(chan struct{}),
+	}
+	ctx.queue <- ctx.currentBatch
+	return ctx.currentBatch
+}
+
+func (ctx *loggingContext) setExecutionID(id string) {
+	ctx.execIDMutex.Lock()
+	ctx.execID = id
+	ctx.execIDMutex.Unlock()
+}
+
+func (ctx *loggingContext) executionID() string {
+	ctx.execIDMutex.RLock()
+	defer ctx.execIDMutex.RUnlock()
+	return ctx.execID
+}
+
+func (ctx *loggingContext) addEntry(entry *logEntry) bool {
+	if ctx.queue == nil {
+		return false
+	}
+
+	ctx.queueMutex.Lock()
+	defer ctx.queueMutex.Unlock()
+
+	// Start a new batch if the current one would grow too much.
+	if len(ctx.currentBatch.Entries) > 0 &&
+		(len(ctx.currentBatch.Entries)+1 > maxLogBatchEntries ||
+			ctx.currentBatch.payloadLength+len(entry.TextPayload) > maxLogBatchLength) {
+		ctx.startNewBatch()
+	}
+
+	ctx.currentBatch.addEntry(entry)
+
+	return true
+}
+
+func (ctx *loggingContext) startReportWorker() {
+	for logBatch := range ctx.queue {
+		<-logBatch.ready
+
+		ctx.queueMutex.Lock()
+		if logBatch == ctx.currentBatch {
+			ctx.startNewBatch()
+		}
+		ctx.queueMutex.Unlock()
+
+		if err := logBatch.report(); err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			killInstance()
+		}
+	}
+}
+
+func (ctx *loggingContext) initialize() {
+	ctx.initOnce.Do(func() {
+		ctx.queue = make(chan *logBatch, 5)
+		ctx.startNewBatch()
+		go ctx.startReportWorker()
+	})
+}
+
+var loggingCtx loggingContext
+
+var (
+	infoLogWriter  supervisorWriter = "INFO"
+	errorLogWriter supervisorWriter = "ERROR"
+
+	// InfoLogger is a logger that batches sends logs to the supervisor with a
+	// severity level of INFO.
+	InfoLogger = log.New(infoLogWriter, "", 0)
+	// InfoLogger is a logger that batches sends logs to the supervisor with a
+	// severity level of ERROR.
+	ErrorLogger = log.New(errorLogWriter, "", 0)
+)
+
+func init() {
+	if supervisorHostname != "" && supervisorInternalPort != "" {
+		loggingCtx.initialize()
+	}
+}
+
+const isoTimeFormat = "2006-01-02T15:04:05.999Z07:00"
+
+type supervisorWriter string
+
+// Write implements io.Writer.Write.
+func (w supervisorWriter) Write(p []byte) (int, error) {
+	entry := &logEntry{
+		TextPayload: string(p),
+		Severity:    string(w),
+		Time:        time.Now().Format(isoTimeFormat),
+		ExecutionID: loggingCtx.executionID(),
+	}
+
+	if !loggingCtx.addEntry(entry) {
+		return os.Stderr.Write(entry.consoleOutput())
+	}
+
+	return len(entry.TextPayload), nil
+}
+
+func newSupervisorRequest(path string, v interface{}) (*http.Request, error) {
+	postData, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", (&url.URL{
+		Scheme: "http",
+		Host:   supervisorHostname + ":" + supervisorInternalPort,
+		Path:   path,
+	}).String(), bytes.NewBuffer(postData))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Content-Length", strconv.Itoa(len(postData)))
+
+	return req, nil
+}
+
+func doRequestWithContext(ctx context.Context, r *http.Request) (*http.Response, error) {
+	resp, err := http.DefaultClient.Do(r.WithContext(ctx))
+	if err != nil {
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		default:
+		}
+	}
+	return resp, err
+}
+
+func postToSupervisor(path string, v interface{}, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req, err := newSupervisorRequest(path, v)
+	if err != nil {
+		return err
+	}
+
+	resp, err := doRequestWithContext(ctx, req)
+	if err == ctx.Err() {
+		return errors.New("timeout when calling supervisor")
+	} else if err != nil {
+		return fmt.Errorf("error when calling supervisor: %s\n\n%s\n", err.Error(), debug.Stack())
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err = fmt.Errorf("incorrect response code from supervisor: %d\n", resp.StatusCode)
+	}
+
+	return err
+}
+
+func killInstance() {
+	err := postToSupervisor("/_ah/kill", nil, supervisorKillTimeout)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+	}
+	// Exit code 16 is copied over from worker.js.
+	os.Exit(16)
+}
+
+func loggerMiddleware(handler http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		loggingCtx.setExecutionID(r.Header.Get("Function-Execution-Id"))
+
+		defer func() {
+			loggingCtx.setExecutionID("")
+		}()
+
+		handler.ServeHTTP(w, r)
+	}
+}
+
+// WithLogger returns an http.Handler that reads the function execution ID,
+// attaches it to log messages sent to the supervisor.
+func WithLogger(handler http.Handler) http.Handler {
+	return loggerMiddleware(handler)
+}
+
+// WithLoggerFunc is the same as WithLogger but accepts a handler function.
+func WithLoggerFunc(handler http.HandlerFunc) http.HandlerFunc {
+	return loggerMiddleware(handler)
+}
+
+// OverrideLogger sets the default logger output to the supervisor logger with
+// a severity level of INFO.
+func OverrideLogger() {
+	log.SetOutput(infoLogWriter)
+	log.SetFlags(0)
+}


### PR DESCRIPTION
Resolves #13. 

The batching logic mirrors that of the logger from the worker.js retrieved by following the instructions from #16.

The logger may be used directly:
```
nodego.InfoLogger.Println("Hello World!")
```
or via the `log` package after calling `nodego.OverrideLogger()`
```
func init() {
	nodego.OverrideLogger()
}

...

log.Println("Hello World")
```