### PR TITLE
Add support for testing without node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,16 +19,19 @@ all: go js
 	zip -FS -r $(OUT) $(GOBIN) node_modules index.js package.json -x *build*
 
 go: FORCE
-	GOARCH="amd64" GOOS="linux" go build -tags netgo $(GOBIN).go
+	GOARCH="amd64" GOOS="linux" go build -tags netgo node $(GOBIN).go
 
 js: FORCE
 	npm install --save local_modules/execer
 
 localgo: FORCE
-	go build $(GOBIN).go
+	go build -tags node $(GOBIN).go
 
 clean: FORCE
 	rm -rf $(GOBIN) $(OUT) node_modules
+
+godev: FORCE
+	go run $(GOBIN).go
 
 test: js localgo
 	node testserver.js

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ For normal development, it should only be necessary to modify the main.go file. 
 ## Local Testing
 Run ```make test``` to compile your code and start the test server. Open ```http://localhost:8080/execute``` in your browser. The page should display ```User function is ready```. Refresh the page to talk to your code.
 
+When using a go-only or non-unix environment, run ```make godev``` instead.
+
 ## Deployment
 Run ```make``` to compile and package your code. Upload the generated ```function.zip``` file to Google Cloud Functions as an HTTP trigger function.
 

--- a/nodego/env.go
+++ b/nodego/env.go
@@ -1,0 +1,3 @@
+package nodego
+
+const HTTPTrigger = "/execute"

--- a/nodego/nodego.go
+++ b/nodego/nodego.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build node
+
 // Package nodego provides utilities for pretending to be node.
 package nodego
 
@@ -26,8 +28,6 @@ import (
 	"strings"
 	"sync"
 )
-
-const HTTPTrigger = "/execute"
 
 var fds = flag.String("fds", "", "fd1,fd2,...")
 

--- a/nodego/nodego_local.go
+++ b/nodego/nodego_local.go
@@ -1,0 +1,41 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !node
+
+package nodego
+
+import (
+	"flag"
+	"log"
+	"net"
+	"net/http"
+)
+
+var address = flag.String("addr", ":8080", "host and port number")
+
+// TakeOver listens and servers http.DefaultServeMux on the address passed by a
+// command line flag.
+func TakeOver() {
+	lis, err := net.Listen("tcp", *address)
+	if err != nil {
+		panic(err)
+	}
+
+	log.Println("listening on", lis.Addr().String())
+
+	if err := http.Serve(lis, nil); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Running `make godev` will run the go binary directly instead of running `testserver.js` node module first.

This also enables the testing of functions on go-only or non-unix (i.e. windows) development environments.

Also helps with #6 