### PR TITLE
Fixed go make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: go js
 	zip -FS -r $(OUT) $(GOBIN) node_modules index.js package.json -x *build*
 
 go: FORCE
-	GOARCH="amd64" GOOS="linux" go build -tags netgo node $(GOBIN).go
+	GOARCH="amd64" GOOS="linux" go build -tags netgo -tags node $(GOBIN).go
 
 js: FORCE
 	npm install --save local_modules/execer


### PR DESCRIPTION
should be 
```
go build -tags netgo -tags node $(GOBIN).go
```
instead of 
```
go build -tags netgo node $(GOBIN).go
```