### PR TITLE
Fix supervisor request error handling

### DIFF
--- a/nodego/supervisor.go
+++ b/nodego/supervisor.go
@@ -245,9 +245,10 @@ func postToSupervisor(path string, v interface{}, timeout time.Duration) error {
 	}
 
 	resp, err := doRequestWithContext(ctx, req)
-	if err == ctx.Err() {
-		return errors.New("timeout when calling supervisor")
-	} else if err != nil {
+	if err != nil {
+		if err == ctx.Err() {
+			return errors.New("timeout when calling supervisor")
+		}
 		return fmt.Errorf("error when calling supervisor: %s\n\n%s\n", err.Error(), debug.Stack())
 	}
 


### PR DESCRIPTION
Resolves #24 

The problem is that `ctx.Err()` is actually `nil` before `ctx.Done()` is closed. So, it was checking for `err == nil` and then returning a timeout error, in turn killing the instance.

https://golang.org/pkg/context/#Context