### PR TITLE
Add windows make script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ After an initial bootstrap step, the only thing running is a pure Go binary. Thi
 A native module calls execve(2) without the normal preceding fork(2) call when the user module is imported. Open socket FDs are preserved and handled by the new Go process to ensure a smooth transition. The new Go process then pretends to be Node.
 
 ## Requirements
-There are two supported environments:
+There are four supported environments:
 
 ### Native
 For advanced users who don't like VirtualBox.
@@ -36,6 +36,12 @@ In the `cloud-functions-go` directory, run `vagrant up` to start the envirement 
 * [Cygwin](https://cygwin.com/install.html) with `make` and `zip` (you may also want `git` and an editor like `vim` or `nano`)
 
 Use the Cygwin Terminal to run the commands as described below. Note that `make test` won't work under Windows.
+
+### Windows with Powershell 5.0
+* Go 1.5 or above
+* Node.js (optional)
+
+The commands described below may be run as-is using Command Prompt, or prefixed with `./` using Windows PowerShell (i.e. `./make` or `./make godev`). Note that `make test` won't work under Windows.
 
 ## Hello, world!
 A demo hello world example is included. To try it out, simply skip to the [Deployment](#deployment) section.

--- a/make.cmd
+++ b/make.cmd
@@ -1,0 +1,59 @@
+@echo off
+
+setlocal
+
+set GOBIN=main
+set OUT=function.zip
+
+if "%1"=="" goto :BUILD_ALL
+if "%1"=="all" goto :BUILD_ALL
+if "%1"=="godev" goto :GO_DEV
+if "%1"=="clean" goto :CLEAN
+
+echo Invalid make target "%1"
+exit /b 2
+
+:BUILD_ALL
+    call :GCF_JS
+    if %errorlevel% neq 0 exit /b %errorlevel%
+
+    call :GCF_GO
+    if %errorlevel% neq 0 exit /b %errorlevel%
+
+    powershell -command "& {& 'Compress-Archive' -DestinationPath %OUT% -Path %GOBIN%,node_modules,index.js,package.json -Force}"
+
+    goto :EOF
+
+:GCF_JS
+    npm install --ignore-scripts --save local_modules/execer 2>nul || (
+        rem Fallback in case npm is unavailable.
+        if exist node_modules\execer (
+            set errorlevel=0
+            goto :EOF
+        )
+
+        if not exist node_modules mkdir node_modules
+        mklink /d node_modules\execer ..\local_modules\execer
+    )
+
+    goto :EOF
+
+:GCF_GO
+    setlocal
+    set GOARCH=amd64
+    set GOOS=linux
+    go build -tags netgo -tags node %GOBIN%.go
+    endlocal
+
+    goto :EOF
+
+:GO_DEV
+    go run %GOBIN%.go
+
+    goto :EOF
+
+:CLEAN
+    rmdir /s /q node_modules
+    del /s %GOBIN% %OUT%
+
+    goto :EOF


### PR DESCRIPTION
I've created a batch script to mimic the linux make commands. `make`, `make all`, `make godev`, `make clean` should all now work natively on windows without having a make port installed.

I've also added a fallback in case npm is not installed. This effectively reduces the windows requirements down to only Go.

There is a potential bug related to the usability of this PR on GCF however. I've submitted a bug report for it upstream: https://issuetracker.google.com/issues/72808534.

Regarding the README edits, is there any particular reason that Go version 1.5 or above must be used?