### PR TITLE
Explicitly disable cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: gcfgo gcfjs
 	zip -FS -r $(OUT) $(GOBIN) node_modules index.js package.json -x *build*
 
 gcfgo: FORCE
-	GOARCH="amd64" GOOS="linux" go build -tags netgo -tags node $(GOBIN).go
+	GOARCH="amd64" GOOS="linux" CGO_ENABLED=0 go build -tags node $(GOBIN).go
 
 gcfjs: FORCE
 	npm install --ignore-scripts --save local_modules/execer

--- a/make.cmd
+++ b/make.cmd
@@ -42,7 +42,8 @@ exit /b 2
     setlocal
     set GOARCH=amd64
     set GOOS=linux
-    go build -tags netgo -tags node %GOBIN%.go
+    set CGO_ENABLED=0
+    go build -tags node %GOBIN%.go
     endlocal
 
     goto :EOF


### PR DESCRIPTION
The netgo tag does not seem to be effective.